### PR TITLE
Add support for Python syntax checking

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1,23 +1,96 @@
+import os, traceback, json, tempfile
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pygit2 import clone_repository, GIT_OBJ_BLOB, GIT_OBJ_TREE
+from ast import parse
 
 hostName = "localhost"
 serverPort = 8080
 
-class CIServer(BaseHTTPRequestHandler):
+class CIServer(HTTPServer):
+    """
+    This class is for the most part identical to the HTTPServer class.
+    However, it also allows the server to be started with the run method
+    whose only purpose is to be run in a thread when running unit tests.
+    Additionally, it prints a message when started and stopped.
+    It can be conventiently shut down using the inherited shutdown method.
+    """
+    def run(self):
+        print("Server started.")
+        try:
+            self.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            print("Server stopped.")
+            self.server_close()
+
+class CIServerHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         """
-        This is the main method for the CI server since GitHub delivers webhooks via POST. 
+        This is the main method for the CI server since GitHub delivers webhooks via POST.
+        It attempts to read the received DATA as a GitHub-generated JSON from a push that
+        contains a repository URL and a reference to a branch. It then tries to parse all
+        Python source code in the repository and displays which files contain syntax errors.
         """
+        # Read POST data
+        content_length = int(self.headers.get("Content-Length"))
+        raw_post_data = self.rfile.read(content_length)
+        try:
+            post_data = json.loads(raw_post_data.decode("utf-8"))
+        except json.JSONDecodeError:
+            print("Malformed JSON received!")
+            self.send_response(400)
+            return
+
         # Send response code & headers
         self.send_response(200)
         self.send_header("Content-type", "text/html")
         self.end_headers()
 
-        # Do CI stuff here
-        # Clone repo, do syntax check etc.
+        try:
+            repository_url = post_data["repository"]["clone_url"]
+            branch_name = "/".join(post_data["ref"].split("/")[2:])
+        except KeyError:
+            print("Invalid JSON received: one or more required fields are missing!")
+            self.send_response(400)
+            return
+
+        # Clone repository
+        with tempfile.TemporaryDirectory() as repo_path:
+            repo = clone_repository(repository_url, repo_path, checkout_branch=branch_name)
+            head_commit = repo.revparse_single(branch_name)
+            tree = head_commit.tree            
+            syntax_errors = self.__try_compile_all(tree, repo_path)
+            print("All source files checked:", syntax_errors, "syntax errors")
+            
+            if repo is not None:
+                repo.free()
 
         # Send response data
         self.wfile.write(bytes("CI jobs done!", "utf-8"))
+
+    def __try_compile_all(self, tree, repo_path, relative_path=""):
+        """
+        This method recursively iterates through a git tree and attempts to parse every file containing Python source code,
+        which it identifies using the .py file extension. It takes three arguments: a git tree, a path to the repository
+        containing the tree, and the relative path to the tree within the repository. If the tree represents the entire
+        repository, the relative path should be set to an empty string.
+        """
+        errors = 0
+        for item in tree:
+            if item.type == GIT_OBJ_BLOB and item.name.endswith(".py") and not item.name.startswith("__init__.py"):
+                with open(os.path.join(repo_path, relative_path, item.name), "r") as f:
+                    source = f.read()
+                try:
+                    parse(source)
+                    print("OK:", os.path.join(relative_path, item.name))
+                except SyntaxError:
+                    errors += 1
+                    print("ERR:", os.path.join(relative_path, item.name))
+                    traceback.print_exc()  # Silence errors
+            elif item.type == GIT_OBJ_TREE:
+                errors += self.__try_compile_all(item, repo_path, os.path.join(relative_path, item.name))
+        return errors
 
     def do_GET(self):
         """
@@ -31,13 +104,5 @@ class CIServer(BaseHTTPRequestHandler):
 
 if __name__ == "__main__":   
     # Used https://pythonbasics.org/webserver/ as a base for the server     
-    webServer = HTTPServer((hostName, serverPort), CIServer)
-    print("Server started.")
-
-    try:
-        webServer.serve_forever()
-    except KeyboardInterrupt:
-        pass
-
-    webServer.server_close()
-    print("Server stopped.")
+    webServer = CIServer((hostName, serverPort), CIServerHandler)
+    webServer.run()

--- a/src/test/invalid_files/hello_world_invalid.py
+++ b/src/test/invalid_files/hello_world_invalid.py
@@ -1,0 +1,1 @@
+        print("Hello, world!")

--- a/src/test/test_server.py
+++ b/src/test/test_server.py
@@ -1,0 +1,82 @@
+import os, shutil, tempfile, pygit2, src.server
+from threading import Thread
+from requests import post
+from time import sleep
+
+def create_repo_with_file_and_commit(repo_path, file_added):
+    """
+    Initializes a git repo in repo_path and copies a file with path file_added
+    to the newly initialized repo, creates a commit, then returns the repo.
+    """
+    # Add test file
+    shutil.copy(file_added, repo_path)
+
+    # Create repo
+    repo = pygit2.init_repository(repo_path, initial_head="main", bare=False)
+
+    # Stage
+    index = repo.index
+    index.add_all()
+    index.write()
+
+    # Prepare to commit
+    ref = "HEAD"
+    author = pygit2.Signature("Pytest", "pytest@example.com")
+    committer = pygit2.Signature("Pytest", "pytest@example.com")
+    message = "Pytest commit message"
+    tree = index.write_tree()
+    parents = []
+
+    # Commit
+    repo.create_commit(ref, author, committer, message, tree, parents)
+    return repo
+
+def test_compile_valid_file(capsys):
+    """
+    Tests that the server correctly clones a remote repository, runs syntax checking
+    and detects no errors for a project consisting of a single valid Python file.
+    """
+    web_server = src.server.CIServer((src.server.hostName, src.server.serverPort), src.server.CIServerHandler)
+    thread = Thread(target = web_server.run, args = ()) # Thread writes to stdout
+    thread.start()
+
+    # Create repo and commit
+    with tempfile.TemporaryDirectory() as local_repo_path:
+        _ = create_repo_with_file_and_commit(local_repo_path, os.path.join(".", "src", "test", "valid_files", "hello_world.py"))
+        post_data = {
+            "repository": {
+                "clone_url": local_repo_path
+            },
+            "ref": "refs/heads/main"
+        }
+        r = post("http://localhost:"+str(src.server.serverPort), json=post_data)
+
+    web_server.shutdown()
+
+    out, _ = capsys.readouterr()
+    assert "OK: hello_world.py\nAll source files checked: 0 syntax errors\n" in out
+
+def test_compile_invalid_file(capsys):
+    """
+    Tests that the server correctly clones a remote repository, runs syntax checking
+    and detects an error for a project consisting of a single invalid Python file.
+    """
+    web_server = src.server.CIServer((src.server.hostName, src.server.serverPort), src.server.CIServerHandler)
+    thread = Thread(target = web_server.run, args = ()) # Thread writes to stdout
+    thread.start()
+
+    # Create repo and commit
+    with tempfile.TemporaryDirectory() as local_repo_path:
+        _ = create_repo_with_file_and_commit(local_repo_path, os.path.join(".", "src", "test", "invalid_files", "hello_world_invalid.py"))
+        post_data = {
+            "repository": {
+                "clone_url": local_repo_path
+            },
+            "ref": "refs/heads/main"
+        }
+        r = post("http://localhost:"+str(src.server.serverPort), json=post_data)
+
+    web_server.shutdown()
+
+    out, _ = capsys.readouterr()
+    assert "ERR: hello_world_invalid.py\nAll source files checked: 1 syntax errors\n" in out

--- a/src/test/valid_files/hello_world.py
+++ b/src/test/valid_files/hello_world.py
@@ -1,0 +1,5 @@
+def main():
+    print("Hello, world!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The CI server will now read JSON data sent with POST, clone a repository and attempt to parse every Python file in the repository to detect syntax errors. This also adds two unit tests, one that submits a repository with valid code and one that submits a repository with invalid code.

Fixes #4

Co-authored-by: editf <editf@users.noreply.github.com>