### PR TITLE
Remove traceback printing

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1,4 +1,4 @@
-import os, traceback, json, tempfile, pytest
+import os, json, tempfile, pytest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pygit2 import clone_repository, GIT_OBJ_BLOB, GIT_OBJ_TREE
 from ast import parse
@@ -97,7 +97,6 @@ class CIServerHandler(BaseHTTPRequestHandler):
                 except SyntaxError:
                     errors += 1
                     print("ERR:", os.path.join(relative_path, item.name))
-                    traceback.print_exc()  # Silence errors
             elif item.type == GIT_OBJ_TREE:
                 errors += self.__try_compile_all(item, repo_path, os.path.join(relative_path, item.name))
         return errors


### PR DESCRIPTION
The traceback should not be displayed when a file has invalid syntax because it does not indicate the nature of the syntax error, but rather the sequence of function calls prior to the parse call.

Fixes #16